### PR TITLE
Add timeout for build time.

### DIFF
--- a/measure_cocoapod_size.py
+++ b/measure_cocoapod_size.py
@@ -27,6 +27,7 @@ import os
 import tempfile
 from collections import OrderedDict
 from xcode_project_diff import GenerateSizeDifference
+from utils import shell
 
 OBJC_APP_DIR = 'sizetestproject'
 OBJC_APP_NAME = 'SizeTest'
@@ -69,8 +70,8 @@ def InstallPods(cocoapods, target_dir, spec_repos, target_name, mode, pod_source
   """
   cwd = os.getcwd()
   os.chdir(target_dir)
-  os.system('pod init')
-  os.system('touch Podfile')
+  shell('pod init')
+  shell('touch Podfile')
 
   with open('Podfile', 'w') as podfile:
     for repo in spec_repos:
@@ -91,8 +92,8 @@ def InstallPods(cocoapods, target_dir, spec_repos, target_name, mode, pod_source
       else:
         podfile.write(' pod \'{}\'\n'.format(pod))
     podfile.write('end')
-  os.system('cat Podfile')
-  os.system('pod install')
+  shell('cat Podfile')
+  shell('pod install')
   os.chdir(cwd)
   return os.path.join(target_dir, '{}.xcworkspace'.format(target_name))
 
@@ -104,7 +105,7 @@ def CopyProject(source_dir, target_dir):
     source_dir: The path to the source directory.
     target_dir: The path to the target directory.
   """
-  os.system('cp -r {} {}'.format(source_dir, target_dir))
+  shell('cp -r {} {}'.format(source_dir, target_dir))
 
 def ValidateSourceConfig(pod_sources):
   for sdk , source in pod_sources.items():
@@ -177,7 +178,7 @@ def GetPodSizeImpact(parsed_args):
                                 '{}/{}.xcodeproj'.format(sample_app_dir, sample_app_name))
 
   source_size, target_size = GenerateSizeDifference(
-      source_project, sample_app_name, target_project, sample_app_name)
+      source_project, sample_app_name, target_project, sample_app_name, parsed_args.build_timeout)
   print('The pods combined add an extra size of {} bytes'.format(
       target_size - source_size))
 
@@ -225,6 +226,13 @@ def Main():
       }
       If versions are specified in `cocoapods`, config here will be skipped.
       ''')
+  parser.add_argument(
+      '--build_timeout',
+      metavar='SECONDS',
+      nargs='?',
+      required=False,
+      default=None,
+      help='Timeout to build testapps.')
 
   args = parser.parse_args()
 

--- a/measure_cocoapod_size.py
+++ b/measure_cocoapod_size.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#!/usr/bin/python
 """measure_cocoapod_size.py provides size impact of a given set of cocoapods.
 
 Usage: ./measure_cocoapod_size.py -cocoapods $POD_NAME:$POD_VERSION

--- a/utils.py
+++ b/utils.py
@@ -18,7 +18,7 @@ import subprocess
 
 def shell(command, timeout=None):
   try:
-    subprocess.run(command, shell = True, check = True, timeout=timeout)
+    subprocess.run(command, shell=True, check=True, timeout=timeout)
   except subprocess.CalledProcessError as e:
     print ('Command error: {} \n {}'.format(command, e))
   except subprocess.TimeoutExpired as e:

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,27 @@
+#!/usr/bin/python
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import subprocess
+
+def shell(command, timeout=None):
+  try:
+    subprocess.run(command, shell = True, check = True, timeout=timeout)
+  except subprocess.CalledProcessError as e:
+    print ('Command error: {} \n {}'.format(command, e))
+  except subprocess.TimeoutExpired as e:
+    if timeout:
+      print ('Time out is set to {} secs.'.format(timeout))
+    print ('Command times out: {} \n {}'.format(command, e))

--- a/xcode_project_diff.py
+++ b/xcode_project_diff.py
@@ -150,11 +150,11 @@ def GenerateSizeDifference(source_project, source_scheme, target_project,
   target_project_dir = os.path.dirname(target_project)
   cur_dir = os.getcwd()
   os.chdir(source_project_dir)
-  shell(source_cmd, timeout = build_timeout)
+  shell(source_cmd, timeout=build_timeout)
   source_final_binary_size = GetFinalBinarySize(ARCHIVE_PATH)
   os.chdir(cur_dir)
   os.chdir(target_project_dir)
-  shell(target_cmd, timeout = build_timeout)
+  shell(target_cmd, timeout=build_timeout)
   target_final_binary_size = GetFinalBinarySize(ARCHIVE_PATH)
   os.chdir(cur_dir)
   return source_final_binary_size, target_final_binary_size

--- a/xcode_project_diff.py
+++ b/xcode_project_diff.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#!/usr/bin/python
 """xcode_project_diff.py provides size difference between two Xcode targets.
 
 This tool takes in an Xcode project file and targets of source and destination
@@ -26,6 +25,7 @@ import argparse
 import json
 import os
 import subprocess
+from utils import shell
 
 SIZE_CONFIG_PATH = 'size_build_configuration.json'
 ARCHIVE_PATH = 'out.xcarchive'
@@ -121,7 +121,7 @@ def GetFinalBinarySize(archive_path):
 
 
 def GenerateSizeDifference(source_project, source_scheme, target_project,
-                           target_scheme):
+                           target_scheme, build_timeout):
   """GenerateSizeDifference generates the final binary size.
 
   Args:
@@ -129,6 +129,7 @@ def GenerateSizeDifference(source_project, source_scheme, target_project,
     source_scheme:  The scheme of the source project.
     target_project: The path to the target project.
     target_scheme:  The scheme of the target project.
+    build_timeout:  Timeout to build testapps.
 
   Returns:
     a touple containing the final binary sizes.
@@ -149,11 +150,11 @@ def GenerateSizeDifference(source_project, source_scheme, target_project,
   target_project_dir = os.path.dirname(target_project)
   cur_dir = os.getcwd()
   os.chdir(source_project_dir)
-  os.system(source_cmd)
+  shell(source_cmd, timeout = build_timeout)
   source_final_binary_size = GetFinalBinarySize(ARCHIVE_PATH)
   os.chdir(cur_dir)
   os.chdir(target_project_dir)
-  os.system(target_cmd)
+  shell(target_cmd, timeout = build_timeout)
   target_final_binary_size = GetFinalBinarySize(ARCHIVE_PATH)
   os.chdir(cur_dir)
   return source_final_binary_size, target_final_binary_size
@@ -173,12 +174,14 @@ def Main():
       '--target_project', required=True, help='The path to the target project')
   parser.add_argument(
       '--target_scheme', required=True, help='The scheme of the target project')
+  parser.add_argument(
+      '--build_timeout', default=None, required=False, help='Timeout to build testapps')
 
   args = parser.parse_args()
 
   source_size, target_size = GenerateSizeDifference(
       args.source_project, args.source_scheme, args.target_project,
-      args.target_scheme)
+      args.target_scheme, build_timeout)
   diff_size = source_size - target_size
   if source_size > target_size:
     print('{} is {} larger than {}'.format(args.source_project, diff_size,


### PR DESCRIPTION
1. Add timeout for testapp build.
2. Exit when shell command failed, `os.system` will only return exit code but not fail the process.
3. The `subprocess` with timeout will not be compatible with PY2.