### PR TITLE
Add ios version setup.

### DIFF
--- a/measure_cocoapod_size.py
+++ b/measure_cocoapod_size.py
@@ -197,8 +197,10 @@ def GetPodSizeImpact(parsed_args):
     if pod_sources: ValidateSourceConfig(pod_sources)
   except ValueError as e:
     raise ValueError("could not decode JSON value %s: %s" % (parsed_args.cocoapods_source_config.name, e))
-  # Set iOS version for the project, a default version of iOS will be added if
-  # the version is not specified.
+  # Set iOS version for the project, the lowest iOS version of all targets
+  # will be added if the version is not specified. Since there is only one
+  # target in either the Objectve-C or the Swift testapp project, the version
+  # will be the one of the target.
   ios_version = parsed_args.ios_version
   if ios_version is None:
     with open(SIZE_CONFIG_PATH, 'r') as size_config:

--- a/measure_cocoapod_size.py
+++ b/measure_cocoapod_size.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 #
 # Copyright 2018 Google LLC
 #
@@ -32,6 +32,8 @@ OBJC_APP_DIR = 'sizetestproject'
 OBJC_APP_NAME = 'SizeTest'
 SWIFT_APP_DIR = 'SwiftApp'
 SWIFT_APP_NAME = 'SwiftApp'
+SIZE_CONFIG_PATH = 'size_build_configuration.json'
+IOS_VERSION_KEY = 'iOSVersion'
 
 MODE_SWIFT = 'swift'
 MODE_OBJC = 'objc'
@@ -56,7 +58,7 @@ def GetSampleApp(mode):
     return OBJC_APP_DIR, OBJC_APP_NAME
 
 
-def InstallPods(cocoapods, target_dir, spec_repos, target_name, mode, pod_sources):
+def InstallPods(cocoapods, target_dir, spec_repos, target_name, mode, pod_sources, ios_version):
   """InstallPods installs the pods.
 
   Args:
@@ -66,6 +68,7 @@ def InstallPods(cocoapods, target_dir, spec_repos, target_name, mode, pod_source
     target_name: The name of the target.
     mode: The type of cocoapods.
     pod_sources: A dict of Pod mapping to its source.
+    ios_version: iOS version of the project.
 
   Returns:
     The path to the workspace.
@@ -76,6 +79,8 @@ def InstallPods(cocoapods, target_dir, spec_repos, target_name, mode, pod_source
   shell('touch Podfile')
 
   with open('Podfile', 'w') as podfile:
+    if ios_version is not None:
+      podfile.write('platform :ios, \'{}\'\n'.format(ios_version))
     for repo in spec_repos:
       podfile.write('source "{}"\n'.format(repo))
     podfile.write('\n')
@@ -192,6 +197,14 @@ def GetPodSizeImpact(parsed_args):
     if pod_sources: ValidateSourceConfig(pod_sources)
   except ValueError as e:
     raise ValueError("could not decode JSON value %s: %s" % (parsed_args.cocoapods_source_config.name, e))
+  # Set iOS version for the project, a default version of iOS will be added if
+  # the version is not specified.
+  ios_version = parsed_args.ios_version
+  if ios_version is None:
+    with open(SIZE_CONFIG_PATH, 'r') as size_config:
+      config_info = json.loads(size_config.read())
+      ios_version = config_info[IOS_VERSION_KEY] if IOS_VERSION_KEY in config_info else None
+
   base_project = tempfile.mkdtemp()
   target_project = tempfile.mkdtemp()
   target_dir = os.path.join(target_project, sample_app_dir)
@@ -201,7 +214,7 @@ def GetPodSizeImpact(parsed_args):
   target_project = InstallPods(cocoapods,
                                target_dir,
                                spec_repos, sample_app_name, parsed_args.mode,
-                               pod_sources)
+                               pod_sources, ios_version)
   source_project = os.path.join(base_project,
                                 '{}/{}.xcodeproj'.format(sample_app_dir, sample_app_name))
 
@@ -290,6 +303,13 @@ def Main():
       required=False,
       default=None,
       help='Output JSON file.')
+  parser.add_argument(
+      '--ios_version',
+      metavar='IOS_VERSION',
+      nargs='?',
+      required=False,
+      default=None,
+      help='Specify minimum ios version in the Podfile before a project is built.')
 
   args = parser.parse_args()
 

--- a/size_build_configuration.json
+++ b/size_build_configuration.json
@@ -1,6 +1,6 @@
 {
   "appScheme": "SizeTest",
-  "iOSVersion": "8.0",
+  "iOSVersion": null,
   "compilerFlags": {
     "ARCHS": "arm64",
     "CODE_SIGN_IDENTITY": "",

--- a/utils.py
+++ b/utils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 #
 # Copyright 2021 Google LLC
 #

--- a/xcode_project_diff.py
+++ b/xcode_project_diff.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 #
 # Copyright 2018 Google LLC
 #


### PR DESCRIPTION
- Update Shebang to python3
- Add ios_version parameter to specify the minimum version of iOS
  - Cocoapods will set `IPHONEOS_DEPLOYMENT_TARGET` to the version set in Podfile. Adding `IPHONEOS_DEPLOYMENT_TARGET` in `compilerFlags` of `size_build_configuration.json` will override the ios version in xcodebuild.
  - `iOSVersion` is set to null, so if `ios_version` is not set, Podfile will have no platform setup and [a lowest platform/version ](https://github.com/CocoaPods/CocoaPods/blob/dbf61e241f71427209aaae46fd7ec9a049c74e77/lib/cocoapods/installer/analyzer/target_inspector.rb#L149-L150)from all targets will be set automatically. 
  
  The `IPHONEOS_DEPLOYMENT_TARGET` is [10.0](https://github.com/google/cocoapods-size/blob/440300c43ec77a2a94ea70fb4d358d1e540276d0/sizetestproject/SizeTest.xcodeproj/project.pbxproj#L326). Might need to consider if we need to bump the version.