### PR TITLE
Disable loading swift standard libraries to the dummy proj

### DIFF
--- a/size_build_configuration.json
+++ b/size_build_configuration.json
@@ -6,7 +6,8 @@
     "CODE_SIGN_IDENTITY": "",
     "CODE_SIGNING_REQUIRED": "NO",
     "CODE_SIGNING_ALLOWED": "NO",
-    "ENABLE_BITCODE": "NO"
+    "ENABLE_BITCODE": "NO",
+    "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES": "NO"
   },
   "withLinkMap": true,
   "officialData": false


### PR DESCRIPTION
The *.dylib are added by `ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES`. The project does not set the parameter so the project inherit from the iOS Default which is eventually determined by `EMBEDDED_CONTENT_CONTAINS_SWIFT`, so  when a pod contains swift codes,  the archive will package those swift standard libraries.
[related doc](https://developer.apple.com/library/archive/qa/qa1881/_index.html)